### PR TITLE
build: Makefile.boot: Set LORDER only if not already defined

### DIFF
--- a/tools/build/mk/Makefile.boot
+++ b/tools/build/mk/Makefile.boot
@@ -12,7 +12,7 @@ LDFLAGS+=	-L${WORLDTMP}/legacy/usr/lib
 AR:=	/usr/bin/ar
 RANLIB:=	/usr/bin/ranlib
 NM:=	/usr/bin/nm
-LORDER:=	/usr/bin/lorder
+LORDER?=	/usr/bin/lorder
 TSORT:=	/usr/bin/tsort
 # lorder and tsort are used inside a subshell so a missing binary will not give
 # an error but instead produce an empty .a file


### PR DESCRIPTION
lorder is a BSD-specific script which is part of the FreeBSD source
code. For linux, a separate package is needed or the script can be
copied from source to /usr/bin/lorder. Both approaches require root
access.

With this patch, the user can set the location for lorder (e.g the
FreeBSD source code) by using the environment variable LORDER.