### PR TITLE
usr.sbin/rpcgen/Makefile: Add libtirpc header path

### DIFF
--- a/usr.bin/rpcgen/Makefile
+++ b/usr.bin/rpcgen/Makefile
@@ -3,5 +3,6 @@
 PROG=	rpcgen
 SRCS=	rpc_main.c  rpc_clntout.c rpc_cout.c rpc_hout.c rpc_parse.c \
 	rpc_sample.c rpc_scan.c rpc_svcout.c rpc_tblout.c rpc_util.c
+CFLAGS+=-I/usr/include/tirpc
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
Some linux distributions use libtirpc as a replacement for sunrpc. Add
the path to the libtirpc headers when building rpcgen.